### PR TITLE
fixed typo in heading - 'how to use'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Documentation for CrossRef's REST API.
 
-## How to us this repository
+## How to use this repository
 
 This is a simple documentation repo. The following files can help you navigate CrossRef's API:
 


### PR DESCRIPTION
how to us -> how to use