### PR TITLE
add link to new crossref client library written in rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You might be able to avoid reading all this documentation if you instead use one
 - [serrano](https://github.com/sckott/serrano) (Ruby)
 - [rcrossref](https://github.com/ropensci/rcrossref) (R)
 - [crossrefapi](https://github.com/fabiobatalha/crossrefapi) (Python)
+- [crossref-rs](https://github.com/MattsSe/crossref-rs) (rust)
 
 If you know of another library you would like to see listed here, please let us know about it via the [issue tracker](https://github.com/Crossref/rest-api-doc/issues).
 


### PR DESCRIPTION
I implemented a crossref api library and command line interface in rust:
[https://github.com/MattsSe/crossref-rs](https://github.com/MattsSe/crossref-rs)