### PR TITLE
Add description for publisher-location property

### DIFF
--- a/api_format.md
+++ b/api_format.md
@@ -63,6 +63,7 @@
 | content-domain | [Content Domain](#content-domain) | No | Information on domains that support Crossmark for this work |
 | relation | [Relations](#relations) | No | Relations to other works |
 | review | [Review](#review) | No | Peer review metadata |
+| publisher-location | String | No | Location of work's publisher |
 
 
 ## Work Nested Types


### PR DESCRIPTION
The `publisher-location` property is not currently described in the Crossref Metadata API JSON Format file. However, this property is returned by the Crossref's REST API and it is one of the valid selects for the `works` route.